### PR TITLE
Define some dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,16 @@
   "summary": "A simple module for installing the Dropbox client.",
   "author": "rcoleman",
   "description": "",
-  "dependencies": [],
+  "dependencies": [
+  	{
+  		"name":"puppetlabs/stdlib", 
+  		"version_requirement":">=2.2.1"
+  	},
+  	{
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 0.0.1"
+    }
+  ],
   "types": [],
   "checksums": {
     "Modulefile": "cb8df51c165e5cf2affdd1e468943e07",


### PR DESCRIPTION
This addresses issue #2, neither puppetlabs/stdlib or puppetlabs/apt were listed.  This is just a simple change that doesn't address testing or anything.  Not sure what versions are actually required as downcase seems to have always been around but stdlib 2.2.1 was out when apt came out so should be a good starting point.
